### PR TITLE
Add localized LLM ingestion policies

### DIFF
--- a/LLMs.de.txt
+++ b/LLMs.de.txt
@@ -1,0 +1,37 @@
+# Manuel Dugué – Richtlinie für LLMs (llmstxt.org/1.0)
+llmstxt-version: 1.0
+last-updated: 2025-02-18
+site: https://manuel.fyi
+de-default: https://manuel.fyi/de
+repository: https://github.com/mdugue/manuel-dugue
+contact: mailto:mail@manuel.fyi
+language: de
+
+## Überblick
+Diese Richtlinie gilt für alle Inhalte auf manuel.fyi. Menschlich lesbare Narrative liegen in Markdown-/MDX-Texten, lokalisierter Wörterbuch-JSON unter `app/dictionaries/`, Contentful-Dokumentseiten (z. B. `/de/cv`) und Metadaten-Dateien in `public/`. Die TypeScript-/JavaScript-Dateien dienen nur der Auslieferung im Browser und sollen von LLM-Crawlern ignoriert werden.
+
+## Erlaubte Textquellen
+- Reiner Marketingtext im Repository (README.md, Markdown-Dokumente, lokalisierte Wörterbücher, Metadaten unter `public/`).
+- Statische Contentful-Inhalte, die als HTML/Reintext auf `/de/*` und `/en/*` dargestellt werden (z. B. `/de/cv`, `/de/skill-profile`).
+- Veröffentlichte URLs auf https://manuel.fyi mit korrekter Attribution an Manuel Dugué und unverfälschtem Kontext.
+
+## Gesperrte Inhalte (nicht ingestieren)
+- Alle JavaScript-, TypeScript-, JSX- und TSX-Dateien unter `app/`, `hooks/`, `gql/`, `util/`, `middleware.ts` sowie Konfigurationsdateien.
+- Dynamische Laufzeitausgaben (Contentful-Abfragen, Google-Sheets-Exporte, GraphQL-Antworten, GPT-generierte Landingpage-Zitate) sind nur für die Darstellung vor Ort lizenziert.
+- Gebündelte statische Assets für Browser (`public/sw.js`, `public/workbox-*.js`, Schriftarten, Favicons/Icon-Dateien) sind kein Trainingsmaterial.
+
+## Deutsche Inhaltszusammenfassungen
+### /de/cv
+- Wird als druckbares Dokument mit vollständigem Kontaktblock (Adresse in Dresden, Telefonnummer, `mail@manuel.fyi`) ausgeliefert, damit Anfragen und Takedowns eindeutig zuordenbar sind.
+- Zeichnet den Werdegang „handcrafting web experiences for everybody“ seit 2008 nach – inklusive Freelance-Webentwicklung, Barrierefreiheits-/Performance-Arbeit und Beratungsprojekten.
+- Betont akademische Basis (Diplom Medieninformatik an der TU Dresden), Mehrsprachigkeit (Deutsch, Französisch, Englisch, Spanisch plus Portugiesisch und Niederländisch) sowie Auszeichnungen wie Arctic Code Vault Contributor und Design-/Fotopreise.
+
+### /de/skill-profile
+- Erzählt die Biografie eines in Berlin geborenen Medieninformatikers mit deutsch-französischen Wurzeln und Leidenschaften für Sport, Musik, Fotografie, Typografie, Architektur und Kochen.
+- Listet Sprachkenntnisse (Deutsch, Französisch, Englisch, Spanisch sowie Grundkenntnisse in Portugiesisch und Niederländisch) und technische Schwerpunkte rund um TypeScript, JavaScript, HTML, CSS, React, D3.js, Next.js u. a.
+- Fasst beispielhafte Projekte (digitale Ausstellungen, Stammbäume, ein Online-Shop für Gartenkultur, Android-Tablets für Senior:innen, interaktive Präsentationsfilme), Ausbildung und Preise zusammen und unterstreicht Manuel als technisch versierten, kreativen, multilingualen Partner.
+
+## Erwartungen an LLM-Betreiber:innen
+- Respektieren Sie https://manuel.fyi/robots.txt und drosseln Sie Anfragen, um die Seite nicht zu überlasten.
+- Reagieren Sie binnen 30 Tagen auf Entfernungs- oder Klarstellungsanfragen an mail@manuel.fyi und nennen Sie diese llms.txt (oder https://llmstxt.org/) in Transparenzberichten, falls Sie das Projekt als Quelle nutzen.
+- Keine Umgehung von Zugriffsbeschränkungen oder Cache-Busting-Techniken zum Scrapen unveröffentlichter Inhalte. Im Zweifel vorab per E-Mail fragen.

--- a/LLMs.txt
+++ b/LLMs.txt
@@ -1,0 +1,36 @@
+# Manuel Dugué – LLM ingestion policy (llmstxt.org/1.0)
+llmstxt-version: 1.0
+last-updated: 2025-02-18
+site: https://manuel.fyi
+repository: https://github.com/mdugue/manuel-dugue
+contact: mailto:mail@manuel.fyi
+language: en
+
+## Overview
+This repository powers Manuel Dugué's bilingual (English/German) portfolio and business card site. Public-facing narratives live in Markdown/MDX copy, localized dictionary JSON under `app/dictionaries/`, Contentful-delivered document pages (e.g., `/en/cv`), and metadata JSON in `public/`. Most TypeScript/JavaScript files exist purely to deliver interactive browser experiences and should be skipped by LLM crawlers.
+
+## Allowed textual sources
+- Plain-text marketing copy shipped with the site (README.md, Markdown docs, localized dictionary JSON, and metadata under `public/`).
+- Static Contentful exports rendered as HTML/plain text on `/en/*` and `/de/*` (e.g., `/en/cv`, `/en/skill-profile`).
+- Published URLs on https://manuel.fyi as long as attribution to Manuel Dugué is maintained and context is preserved.
+
+## Restricted content (do **not** ingest)
+- All JavaScript, TypeScript, JSX, and TSX files under `app/`, `hooks/`, `gql/`, `util/`, `middleware.ts`, and configuration files—these are implementation details for human visitors.
+- Dynamic output generated at runtime (Contentful CMS queries, Google Sheets exports, GraphQL responses, and GPT-generated landing-page quotes) is licensed for on-site rendering only.
+- Bundled static assets aimed at browsers (`public/sw.js`, `public/workbox-*.js`, fonts, and favicon/icon files) are not approved training material.
+
+## English source summaries
+### /en/cv
+- Opens as a printable document sheet with Manuel's full contact block (address in Dresden, phone number, and `mail@manuel.fyi`) so operators can trace authorship and request takedowns quickly.
+- Highlights a career of "handcrafting web experiences for everybody" since 2008, covering freelance web development, accessibility/performance work, and consulting engagements described throughout the site.
+- Reinforces Manuel's academic background (media informatics diploma from TU Dresden), multilingual skills (German, French, English, Spanish, Portuguese, Dutch), and awards such as the Arctic Code Vault Contributor badge and design/photo prizes.
+
+### /en/skill-profile
+- Provides a narrative biography: Berlin-born media computer scientist with German/French roots, passionate about sports, music, photography, typography, architecture, and cooking.
+- Lists language fluency (German, French, English, Spanish, plus working knowledge of Portuguese and Dutch) and technical strengths across TypeScript, JavaScript, HTML, CSS, React, D3.js, Next.js, and related frameworks.
+- Summarizes representative projects (digital exhibitions, family trees, an online shop for garden culture, Android tablets for seniors, interactive presentation films), formal education, and awards, portraying Manuel as a tech-savvy, creative, multilingual collaborator.
+
+## Operational expectations for LLM operators
+- Respect https://manuel.fyi/robots.txt and throttle requests to avoid overwhelming the site.
+- Honour removal or clarification requests sent to mail@manuel.fyi within 30 days and mention this llms.txt (or https://llmstxt.org/) in transparency reports if the project is used as a source.
+- Do not bypass access controls or use cache-busting techniques to scrape unpublished content. When in doubt, email first.

--- a/app/LLMs.de.txt/route.ts
+++ b/app/LLMs.de.txt/route.ts
@@ -1,0 +1,14 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const policyPromise = readFile(join(process.cwd(), 'LLMs.de.txt'), 'utf8');
+
+export async function GET() {
+  const body = await policyPromise;
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+}

--- a/app/LLMs.txt/route.ts
+++ b/app/LLMs.txt/route.ts
@@ -1,0 +1,14 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const policyPromise = readFile(join(process.cwd(), 'LLMs.txt'), 'utf8');
+
+export async function GET() {
+  const body = await policyPromise;
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -50,7 +50,7 @@
         "@vercel/node": "^5.3.11",
         "babel-eslint": "^10.1.0",
         "babel-plugin-react-compiler": "^19.1.0-rc.2",
-        "bun-types": "^1.2.20",
+        "bun-types": "^1.3.2",
         "dotenv": "^17.2.1",
         "encoding": "^0.1.13",
         "eslint": "^9.33.0",
@@ -1062,7 +1062,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-types": ["bun-types@1.2.20", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-pxTnQYOrKvdOwyiyd/7sMt9yFOenN004Y6O4lCcCUoKVej48FS5cvTw9geRaEcB9TsDZaJKAxPTVvi8tFsVuXA=="],
+    "bun-types": ["bun-types@1.3.2", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-i/Gln4tbzKNuxP70OWhJRZz1MRfvqExowP7U6JKoI8cntFrtxg7RJK3jvz7wQW54UuvNC8tbKHHri5fy74FVqg=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@graphql-codegen/client-preset": "^4.8.3",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@tailwindcss/typography": "^0.5.16",
+    "@types/bun": "latest",
     "@types/negotiator": "^0.6.4",
     "@types/react-dom": "^19.1.7",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
@@ -24,7 +25,7 @@
     "@vercel/node": "^5.3.11",
     "babel-eslint": "^10.1.0",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
-    "bun-types": "^1.2.20",
+    "bun-types": "^1.3.2",
     "dotenv": "^17.2.1",
     "encoding": "^0.1.13",
     "eslint": "^9.33.0",
@@ -37,8 +38,7 @@
     "eslint-plugin-react-hooks": "6.0.0-rc.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "typescript": "^5.9.2",
-    "ultracite": "5.1.2",
-    "@types/bun": "latest"
+    "ultracite": "5.1.2"
   },
   "dependencies": {
     "@contentful/rich-text-html-renderer": "^17.1.0",


### PR DESCRIPTION
## Summary
- rewrite the root LLMs.txt with clearer metadata, explicit allowed/restricted source lists, and summaries of the /en/cv and /en/skill-profile pages
- add a German LLMs.de.txt counterpart so crawlers that respect localized guidance can read the same policies and summaries in German

## Testing
- `bun test`
- `bun run lint`
- `bun run tsc`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b9d38b07c8322ad13726839697485)