### PR TITLE
Enable typed routes and update navigation

### DIFF
--- a/app/[locale]/[sheet]/page.tsx
+++ b/app/[locale]/[sheet]/page.tsx
@@ -5,6 +5,7 @@ import type { AllInOnePageQuery } from "gql/graphql";
 import type { Article, WithContext } from "schema-dts";
 import { DocumentSheetContent } from "@/document-sheet";
 import { graphqlClient } from "@/graphql-client";
+import { assertLocale } from "@/i18n-config";
 import { pageQuery } from "../page-query";
 
 export const runtime = "edge";
@@ -12,6 +13,7 @@ export const revalidate = 60; // 1 minute
 
 export default async function Page({ params }: PageProps<"/[locale]/[sheet]">) {
 	const { sheet, locale } = await params;
+	assertLocale(locale);
 
 	const { allInOnePageCollection } =
 		await graphqlClient.request<AllInOnePageQuery>(pageQuery, {
@@ -20,7 +22,10 @@ export default async function Page({ params }: PageProps<"/[locale]/[sheet]">) {
 		});
 
 	return (
-		<DocumentSheetContent title={allInOnePageCollection?.items[0]?.title || ""}>
+		<DocumentSheetContent
+			locale={locale}
+			title={allInOnePageCollection?.items[0]?.title || ""}
+		>
 			<div
 				className={
 					"prose prose-h1:col-span-4 prose-h3:col-span-3 prose-p:col-span-3 prose-ul:col-span-3 prose-h3:col-start-2 prose-p:col-start-2 prose-ul:col-start-2 prose-h2:mt-0 prose-h3:mt-0 prose-p:mt-0 prose-h1:mb-2 prose-h2:mb-2 prose-h3:mb-0 prose-p:mb-2 grid-cols-4 gap-x-4 prose-h1:self-start prose-h2:hyphens-auto whitespace-pre-line prose-h1:bg-linear-to-tr prose-h2:bg-linear-to-tr prose-h3:bg-linear-to-tr prose-h1:from-amber-500 prose-h2:from-teal-500 prose-h3:from-teal-700 prose-h1:to-amber-300 prose-h2:to-teal-600 prose-h3:to-teal-600 prose-h1:pt-4 prose-a:font-medium prose-h1:font-inline prose-h2:font-bold prose-h3:font-bold prose-a:text-fuchsia-400 prose-h1:text-gradient prose-h1:text-lg prose-h2:text-base prose-h2:text-gradient prose-h3:text-base prose-h3:text-gradient prose-h3:text-gray-700 prose-p:text-gray-800 prose-h2:capitalize prose-h3:capitalize leading-6 prose-a:no-underline prose-a:hover:underline md:grid md:prose-h2:justify-self-end md:prose-h2:text-right"

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -173,14 +173,14 @@ async function LegalSection(props: { locale: Locale }) {
 			<LocaleSwitcher className="flex gap-2" currentLocale={locale} />
 			<Link
 				className="hover:text-gray-400"
-				href={`${locale}/legal`}
+				href={`/${locale}/legal`}
 				prefetch={false}
 			>
 				{dictionary.legal}
 			</Link>
 			<Link
 				className="hover:text-gray-400"
-				href={`${locale}/privacy`}
+				href={`/${locale}/privacy`}
 				prefetch={false}
 			>
 				{dictionary.privacy}

--- a/app/back-on-esc.tsx
+++ b/app/back-on-esc.tsx
@@ -5,7 +5,9 @@ import { useKeyPressEvent } from "react-use";
 export default function BackOnEsc() {
 	const router = useRouter();
 
-	useKeyPressEvent("Escape", () => router.push("."));
+	useKeyPressEvent("Escape", () => {
+		router.back();
+	});
 
 	return null;
 }

--- a/app/document-sheet.tsx
+++ b/app/document-sheet.tsx
@@ -1,7 +1,10 @@
 import { XMarkIcon } from "@heroicons/react/20/solid";
+import type { Route } from "next";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import BackOnEsc from "@/back-on-esc";
+import type { Locale } from "./i18n-config";
+import { i18n } from "./i18n-config";
 
 export default function DocumentSheet(props: { children: ReactNode }) {
 	return (
@@ -23,15 +26,19 @@ export default function DocumentSheet(props: { children: ReactNode }) {
 export function DocumentSheetContent(props: {
 	title?: string;
 	children?: ReactNode;
+	locale?: Locale;
 }) {
-	const { title = "loading …", children } = props;
+	const { title = "loading …", children, locale } = props;
+
+	const resolvedLocale = locale ?? i18n.defaultLocale;
+	const closeHref = `/${resolvedLocale}` as Route;
 
 	return (
 		<>
 			<nav className="absolute top-0 right-0 m-1 flex gap-1 text-gray-400">
 				<Link
 					className="flex cursor-pointer items-center rounded-md px-4 py-4 text-sm hover:bg-linear-to-tr hover:from-teal-100 hover:to-teal-50 hover:text-teal-600 focus:outline-hidden focus:ring-2 focus:ring-teal-600"
-					href="."
+					href={closeHref}
 					title="close"
 				>
 					<XMarkIcon className="h-5 w-5" />

--- a/app/locale-switcher.tsx
+++ b/app/locale-switcher.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Route } from "next";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { i18n, type Locale } from "../app/i18n-config";
@@ -10,13 +11,16 @@ export default function LocaleSwitcher(props: {
 }) {
 	const { currentLocale } = props;
 	const pathName = usePathname();
-	const redirectedPathName = (locale: string) => {
-		if (!pathName) {
-			return "/";
+
+	const redirectedPathName = (locale: Locale): Route => {
+		const segments = pathName?.split("/").filter(Boolean) ?? [];
+		const [, sheet] = segments;
+
+		if (sheet) {
+			return `/${locale}/${sheet}` as Route;
 		}
-		const segments = pathName.split("/");
-		segments[1] = locale;
-		return segments.join("/");
+
+		return `/${locale}` as Route;
 	};
 
 	return (

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
 	reactStrictMode: true,
 	reactCompiler: true,
+	typedRoutes: true,
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- enable Next.js typed routes and update navigation links to use typed hrefs
- validate locale parameters for sheet pages and ensure locale switching builds typed paths
- adjust document sheet close handling and escape navigation to use safer routing

## Testing
- bun run tsc
- bun run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69201e93c3bc83228306723993e1b34f)