### PR TITLE
Shorten hero tagline across all locales

### DIFF
--- a/i18n/dictionaries/de.json
+++ b/i18n/dictionaries/de.json
@@ -6,9 +6,8 @@
     "hero": {
       "eyebrow": "Product Engineer · seit 2004",
       "title": [
-        "Gestalten, entwickeln & ausliefern seit",
-        "zwanzig Jahren —",
-        "stets <em>neugierig.</em>"
+        "Gestalten, entwickeln & ausliefern —",
+        "<em>neugierig</em> seit zwanzig Jahren."
       ],
       "lede": "Manuel Dugué · unabhängiger Product Engineer aus Dresden. Architektur, KI-native Arbeitsweisen, User Experience; am liebsten dort, wo Strategie auf Umsetzung trifft.",
       "facts": {

--- a/i18n/dictionaries/en.json
+++ b/i18n/dictionaries/en.json
@@ -6,11 +6,9 @@
     "hero": {
       "eyebrow": "Independent product engineer · since 2004",
       "title": [
-        "Designing, building",
-        "and shipping for",
-        "the past twenty",
-        "years — and",
-        "<em>counting.</em>"
+        "Designing, building & shipping",
+        "since twenty years —",
+        "<em>and counting.</em>"
       ],
       "lede": "Manuel Dugué · independent product engineer based in Dresden. Architecture, AI-native workflows, User Experience; preferably where strategy meets implementation.",
       "facts": {

--- a/i18n/dictionaries/es.json
+++ b/i18n/dictionaries/es.json
@@ -6,9 +6,8 @@
     "hero": {
       "eyebrow": "Ingeniero de producto · desde 2004",
       "title": [
-        "Diseñar, construir y entregar desde",
-        "hace veinte años —",
-        "todavía <em>curioso.</em>"
+        "Diseñar, construir y entregar —",
+        "<em>curioso</em> desde hace veinte años."
       ],
       "lede": "Manuel Dugué · ingeniero de producto independiente con base en Dresde. Arquitectura, flujos de trabajo nativos para IA, experiencia de usuario; preferiblemente donde la estrategia se encuentra con la implementación.",
       "facts": {

--- a/i18n/dictionaries/fr.json
+++ b/i18n/dictionaries/fr.json
@@ -6,9 +6,8 @@
     "hero": {
       "eyebrow": "Ingénieur produit · depuis 2004",
       "title": [
-        "Concevoir, construire & livrer depuis",
-        "vingt ans —",
-        "toujours <em>curieux.</em>"
+        "Concevoir, construire & livrer —",
+        "<em>curieux</em> depuis vingt ans."
       ],
       "lede": "Manuel Dugué · ingénieur produit indépendant basé à Dresde. Architecture, workflows natifs pour l'IA, expérience utilisateur ; de préférence là où la stratégie rencontre l'exécution.",
       "facts": {


### PR DESCRIPTION
Tightens the hero headline to two punchier lines (three in EN) and
moves the subject after the em-dash for a stronger second-line beat.